### PR TITLE
Provide toggle context to children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budibase-toggle",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "An amazing Budibase component!",
   "license": "MIT",
   "svelte": "index.js",

--- a/schema.json
+++ b/schema.json
@@ -6,6 +6,7 @@
     "friendlyName": "budibase-toggle",
     "description": "An amazing Budibase component!",
     "icon": "Text",
+    "hasChildren": true,
     "settings": [
       {
         "type": "color",
@@ -24,6 +25,22 @@
         "key": "accentColor",
         "label": "Accent Color",
         "defaultValue": "#BAC4C6"
+      }
+    ],
+    "context": [
+      {
+        "type": "schema"
+      },
+      {
+        "type": "static",
+        "values": [
+          {
+            "label": "Active State",
+            "key": "isActive",
+            "type": "boolean",
+            "defaultValue": false
+          }
+        ]
       }
     ]
   }

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -1,26 +1,31 @@
 <script>
   import { getContext } from "svelte"
 
-  const { styleable } = getContext("sdk")
+  const { styleable, Provider } = getContext("sdk")
   const component = getContext("component")
   export let inactiveColor;
   export let activeColor;
   export let accentColor;
 
   let isActive = false;
-
+  $: dataContext = {
+    isActive
+  }
   const handleButtonClick = () => {
     isActive = !isActive;
   };
 </script>
 
 <div use:styleable={$component.styles}>
-  <div class="toggle">
-    <div style="background: {isActive ? activeColor : inactiveColor};" class="toggle-button {isActive && 'toggle-button-active'}" on:click={handleButtonClick}>
-      <div style="background: {accentColor};" class="toggle-inner-circle {isActive && 'toggle-inner-circle-active'}">
+  <Provider data={dataContext}>
+    <div class="toggle">
+      <div style="background: {isActive ? activeColor : inactiveColor};" class="toggle-button {isActive && 'toggle-button-active'}" on:click={handleButtonClick}>
+        <div style="background: {accentColor};" class="toggle-inner-circle {isActive && 'toggle-inner-circle-active'}">
+        </div>
       </div>
     </div>
-  </div>
+    <slot />
+  </Provider>
 </div>
 
 <style>


### PR DESCRIPTION
I realised there was no way for the toggle to pass its state to the Budibase app. I'm creating this PR for you because I had to figure out how to use the context myself 😅  - I'll follow up with some docs tomorrow hopefully.

<img width="583" alt="Screenshot 2022-10-05 at 21 00 27" src="https://user-images.githubusercontent.com/101575380/194151861-d1cff0b6-1b4b-483a-af05-ed513a7f603b.png">

<img width="583" alt="Screenshot 2022-10-05 at 21 00 41" src="https://user-images.githubusercontent.com/101575380/194151901-23a2ac48-a80c-456d-9444-69d710e15f0d.png">

<img width="862" alt="Screenshot 2022-10-05 at 21 01 25" src="https://user-images.githubusercontent.com/101575380/194152057-166fda50-ccd6-4409-a4c3-f657e9fd0d98.png">

<img width="862" alt="Screenshot 2022-10-05 at 21 01 50" src="https://user-images.githubusercontent.com/101575380/194152126-1e6bed60-be95-41dc-858c-5cedb0e5d8f8.png">

So the context provides bindings to the children. You then need to add the Provider component to expose those bindings to the children, which are indicated by the generic `<slot />`.


---

There's a couple of other things you could have done instead. One is as a form component, another would be to add the `onClick` event:
```
{
    "type": "event",
    "label": "On Click",
    "key": "onClick"
  }
``` 

I think the context provider works well for something like a toggle. 